### PR TITLE
Added/updated obsolete warnings

### DIFF
--- a/contentdocs/index.html
+++ b/contentdocs/index.html
@@ -13,8 +13,7 @@
 			<div class="warn">
 				<p><strong>WARNING</strong>: This document is OBSOLETE.</p>
 				<p>Reserved prefixes are defined in the 
-					<a href="https://www.w3.org/publishing/epub3/epub-contentdocs.html#sec-overview-pfx">EPUB 3 
-						Content Documents Specification.</a></p>
+					<a href="https://www.w3.org/TR/epub/#sec-intro-shorthands">EPUB 3 Specification.</a></p>
 			</div>
 			
 			<p><a href="http://www.idpf.org"><img src="../images/idpflogo_web_125.jpg" alt="IDPF" class="logo"/></a></p>

--- a/css/prefixes.css
+++ b/css/prefixes.css
@@ -11,3 +11,15 @@ div.history {
     margin-top: 2em;
     margin-bottom: 2em
 }
+
+div.warn {
+	position: fixed;
+    border: 0.15em solid red;
+	padding-left: 1rem;
+    padding-right: 0.5em;
+    background-color: khaki;
+    top: 0.5rem;
+}
+header {
+    padding-top: 7rem;
+}

--- a/packages/index.html
+++ b/packages/index.html
@@ -12,9 +12,8 @@
 		<header>
 			<div class="warn">
 				<p><strong>WARNING</strong>: This document is OBSOLETE.</p>
-				<p>Reserved prefixes are defined in the 
-					<a href="https://www.w3.org/publishing/epub3/epub-packages.html#sec-overview-pfx">EPUB 3 
-						Packages Specification.</a></p>
+				<p>Reserved prefixes are defined in an appendix of the 
+					<a href="https://www.w3.org/TR/epub/#sec-reserved-prefixes">EPUB 3 Specification.</a></p>
 			</div>
 			
 			<p><a href="http://www.idpf.org"><img src="../images/idpflogo_web_125.jpg" alt="IDPF" class="logo"/></a></p>


### PR DESCRIPTION
Note: the epub-prefixes/contentdocs seems to be messy overall. The original namespaces, the ones in 3.2 and the one in 3.3 seem to be fairly different....